### PR TITLE
Semantic release: fix 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "text_processing_util_mds24"
-version = "0.1.0"
+version = "2.0.1"
 description = "Utility functions for text processing."
 authors = ["Jerry Yu, Nasim Ghazanfari Nasrabadi, Mohammad Norouzi, Allan Lee"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,14 @@ myst-nb = {version = "^1.0.0", python = "^3.9"}
 sphinx-autoapi = "^3.0.0"
 sphinx-rtd-theme = "^2.0.0"
 
+[tool.semantic_release]
+version_toml = [
+    "pyproject.toml:tool.poetry.version",
+]                                                    # version location
+branch = "main"                                      # branch to make releases of
+changelog_file = "CHANGELOG.md"                      # changelog file
+build_command = "pip install poetry && poetry build" # build dists
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Attempt to fix semantic release again based on new information from Slack. Note that I have already updated the release version number on GitHub with a new release.

Addresses #65 